### PR TITLE
Add Time Management System

### DIFF
--- a/examples/example_time.jl
+++ b/examples/example_time.jl
@@ -1,0 +1,50 @@
+#!/usr/bin/env julia
+# This example demonstrates periodic publishing of PoseStamped messages with timestamps.
+
+using ROS2
+
+init()
+
+node = ROSNode("time_example")
+
+pose_pub = Publisher(node, "pose_with_time", "geometry_msgs.msg.PoseStamped")
+
+println("Starting periodic publishing at 10 Hz for 1 minute...")
+
+counter = Ref(0)
+start_time = time()
+
+timer = ROSTimer(
+    node,
+    0.1,  # 10 Hz
+    () -> begin
+        counter[] += 1
+        current_time = now()
+        msg_time = to_msg_time(current_time)
+
+        pose_msg = create_msg("geometry_msgs.msg.PoseStamped")
+        pose_msg.header.stamp = msg_time
+        pose_msg.header.frame_id = "map"
+        pose_msg.pose.position.x = Float64(counter[])
+        pose_msg.pose.position.y = sin(counter[] * 0.1)
+        pose_msg.pose.position.z = 0.0
+        publish(pose_pub, pose_msg)
+
+        println(
+            "Timer callback #$(counter[]) executed - x: $(counter[]), y: $(sin(counter[] * 0.1))",
+        )
+    end,
+)
+
+try
+    while (time() - start_time) < 60.0
+        spin_once(node)
+        sleep(0.1)
+    end
+    println("Finished publishing messages after 1 minute")
+catch e
+    println("Error: $e")
+finally
+    timer_cancel(timer)
+    shutdown()
+end

--- a/src/ROS2.jl
+++ b/src/ROS2.jl
@@ -4,52 +4,8 @@ const rclpy = PyNULL()
 const rclpy_node = PyNULL()
 const py_sys = PyNULL()
 
-function __init__()
-    if contains(lowercase(get(ENV, "GITHUB_WORKFLOW", "")), "automerge")
-        return
-    end
-    
-    try
-        copy!(py_sys, pyimport("sys"))
-        if length(ARGS) > 0
-            py_sys.argv = ARGS
-        end
-        
-        if !(dirname(@__FILE__) in py_sys."path")
-            pushfirst!(py_sys."path", dirname(@__FILE__))
-        end
-        
-        copy!(rclpy, pyimport_conda("rclpy", "rclpy", "conda-forge"))
-        
-        if !haskey(ENV, "AMENT_PREFIX_PATH")
-            @warn "ROS2 environment not sourced"
-            return
-        end
-        
-        copy!(rclpy_node, pyimport("rclpy.node"))
-        
-    catch e
-        @warn "ROS2 initialization deferred: $e"
-    end
-end
-
-#=
-function __init__()
-    if contains(lowercase(get(ENV, "GITHUB_WORKFLOW", "")), "automerge")
-        return
-    end
-    
-    try
-        copy!(rclpy, pyimport_conda("rclpy", "rclpy", "conda-forge"))
-        copy!(rclpy_node, pyimport("rclpy.node"))
-    catch e
-        @warn "ROS2 initialization deferred: $e"
-    end
-end
-=#
-
-# Include submodules
 include("core.jl")
+include("time.jl")
 include("pubsub.jl")
 include("timer.jl")
 include("service.jl")
@@ -57,8 +13,39 @@ include("parameter.jl")
 include("action.jl")
 include("logging.jl")
 
-# Re-export from submodules
+function __init__()
+    if contains(lowercase(get(ENV, "GITHUB_WORKFLOW", "")), "automerge")
+        return
+    end
+
+    try
+        copy!(py_sys, pyimport("sys"))
+        if length(ARGS) > 0
+            py_sys.argv = ARGS
+        end
+
+        if !(dirname(@__FILE__) in py_sys."path")
+            pushfirst!(py_sys."path", dirname(@__FILE__))
+        end
+
+        copy!(rclpy, pyimport_conda("rclpy", "rclpy", "conda-forge"))
+
+        if !haskey(ENV, "AMENT_PREFIX_PATH")
+            @warn "ROS2 environment not sourced"
+            return
+        end
+
+        copy!(rclpy_node, pyimport("rclpy.node"))
+
+        Time.__init_time__()
+
+    catch e
+        @warn "ROS2 initialization deferred: $e"
+    end
+end
+
 using .Core
+using .Time
 using .PubSub
 using .Timer
 using .Service
@@ -66,19 +53,71 @@ using .Parameter
 using .Action
 using .Logging
 
-# Export all symbols from submodules with the updated function names
-export ROSNode, init, shutdown, spin, spin_once, is_ok,  # from Core
-       Publisher, Subscriber, create_msg, publish,  # from PubSub
-       ROSTimer, timer_cancel, timer_reset, timer_is_ready, timer_time_since_last_call,  # from Timer
-       ServiceServer, ServiceClient, create_request, call, call_async,  # from Service
-       wait_for_service, service_is_ready,
-       declare_parameter, declare_parameters, get_parameter, set_parameter,  # from Parameter
-       has_parameter, get_parameter_types,
-       add_on_set_parameters_callback, remove_on_set_parameters_callback,
-       ActionServer, ActionClient, GoalHandle, send_goal, send_goal_sync,  # from Action
-       cancel_goal, create_goal, accept_goal, reject_goal,
-       publish_feedback, succeed, abort,
-       get_logger, debug, info, warn, log_error, fatal, set_level,  # from Logging
-       DEBUG, INFO, WARN, ERROR, FATAL
+export ROSNode,
+    init,
+    shutdown,
+    spin,
+    spin_once,
+    is_ok,  # from Core
+    ROSTime,
+    ROSDuration,
+    ROSClock,
+    now,
+    ros_time_now,
+    to_sec,
+    to_nsec,  # from Time
+    to_msg_time,
+    from_msg_time,
+    to_msg_duration,
+    from_msg_duration,  # from Time
+    builtin_interfaces,  # from Time
+    Publisher,
+    Subscriber,
+    create_msg,
+    publish,  # from PubSub
+    ROSTimer,
+    timer_cancel,
+    timer_reset,
+    timer_is_ready,
+    timer_time_since_last_call,  # from Timer
+    ServiceServer,
+    ServiceClient,
+    create_request,
+    call,
+    call_async,  # from Service
+    wait_for_service,
+    service_is_ready,
+    declare_parameter,
+    declare_parameters,
+    get_parameter,
+    set_parameter,  # from Parameter
+    has_parameter,
+    get_parameter_types,
+    add_on_set_parameters_callback,
+    remove_on_set_parameters_callback,
+    ActionServer,
+    ActionClient,
+    GoalHandle,
+    send_goal,
+    send_goal_sync,  # from Action
+    cancel_goal,
+    create_goal,
+    accept_goal,
+    reject_goal,
+    publish_feedback,
+    succeed,
+    abort,
+    get_logger,
+    debug,
+    info,
+    warn,
+    log_error,
+    fatal,
+    set_level,  # from Logging
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR,
+    FATAL
 
-end # module
+end

--- a/src/time.jl
+++ b/src/time.jl
@@ -1,0 +1,160 @@
+module Time
+
+using PyCall
+
+const rclpy_time = PyNULL()
+const rclpy_clock = PyNULL()
+const rclpy_duration = PyNULL()
+
+function __init_time__()
+    copy!(rclpy_time, pyimport("rclpy.time"))
+    copy!(rclpy_clock, pyimport("rclpy.clock"))
+    copy!(rclpy_duration, pyimport("rclpy.duration"))
+end
+
+mutable struct ROSTime
+    _py_time::PyObject
+
+    function ROSTime(seconds::Real = 0.0, nanoseconds::Integer = 0)
+        py_time = rclpy_time.Time(seconds = seconds, nanoseconds = nanoseconds)
+        new(py_time)
+    end
+
+    function ROSTime(py_time::PyObject)
+        new(py_time)
+    end
+end
+
+mutable struct ROSDuration
+    _py_duration::PyObject
+
+    function ROSDuration(seconds::Real = 0.0, nanoseconds::Integer = 0)
+        py_duration = rclpy_duration.Duration(seconds = seconds, nanoseconds = nanoseconds)
+        new(py_duration)
+    end
+
+    function ROSDuration(py_duration::PyObject)
+        new(py_duration)
+    end
+end
+
+mutable struct ROSClock
+    _py_clock::PyObject
+
+    function ROSClock(clock_type = nothing)
+        if clock_type === nothing
+            py_clock = rclpy_clock.Clock()
+        else
+            py_clock = rclpy_clock.Clock(clock_type = clock_type)
+        end
+        new(py_clock)
+    end
+
+    function ROSClock(py_clock::PyObject)
+        new(py_clock)
+    end
+end
+
+Base.:(+)(t::ROSTime, d::ROSDuration) = ROSTime(t._py_time + d._py_duration)
+Base.:(-)(t::ROSTime, d::ROSDuration) = ROSTime(t._py_time - d._py_duration)
+Base.:(-)(t1::ROSTime, t2::ROSTime) = ROSDuration(t1._py_time - t2._py_time)
+
+Base.:(+)(d1::ROSDuration, d2::ROSDuration) = ROSDuration(d1._py_duration + d2._py_duration)
+Base.:(-)(d1::ROSDuration, d2::ROSDuration) = ROSDuration(d1._py_duration - d2._py_duration)
+Base.:(*)(d::ROSDuration, scalar::Real) = ROSDuration(d._py_duration * scalar)
+Base.:(*)(scalar::Real, d::ROSDuration) = ROSDuration(scalar * d._py_duration)
+
+Base.:(==)(t1::ROSTime, t2::ROSTime) = t1._py_time == t2._py_time
+Base.:(<)(t1::ROSTime, t2::ROSTime) = t1._py_time < t2._py_time
+Base.:(<=)(t1::ROSTime, t2::ROSTime) = t1._py_time <= t2._py_time
+
+Base.:(==)(d1::ROSDuration, d2::ROSDuration) = d1._py_duration == d2._py_duration
+Base.:(<)(d1::ROSDuration, d2::ROSDuration) = d1._py_duration < d2._py_duration
+Base.:(<=)(d1::ROSDuration, d2::ROSDuration) = d1._py_duration <= d2._py_duration
+
+function now(clock::ROSClock = ROSClock())
+    return ROSTime(clock._py_clock.now())
+end
+
+function ros_time_now()
+    return now()
+end
+
+function to_sec(t::ROSTime)
+    return t._py_time.nanoseconds / 1e9
+end
+
+function to_nsec(t::ROSTime)
+    return t._py_time.nanoseconds
+end
+
+function to_sec(d::ROSDuration)
+    return d._py_duration.nanoseconds / 1e9
+end
+
+function to_nsec(d::ROSDuration)
+    return d._py_duration.nanoseconds
+end
+
+module builtin_interfaces
+struct Time
+    sec::Int32
+    nanosec::UInt32
+end
+
+struct Duration
+    sec::Int32
+    nanosec::UInt32
+end
+end
+
+function to_msg_time(t::ROSTime)
+    py"""
+    def create_time_msg(sec, nanosec):
+        from builtin_interfaces.msg import Time
+        msg = Time()
+        msg.sec = int(sec)
+        msg.nanosec = int(nanosec)
+        return msg
+    """
+    ns = t._py_time.nanoseconds
+    sec = ns ÷ 1_000_000_000
+    nanosec = ns % 1_000_000_000
+    return py"create_time_msg"(sec, nanosec)
+end
+
+function from_msg_time(msg_time)
+    sec = msg_time.sec
+    nanosec = msg_time.nanosec
+    total_ns = sec * 1_000_000_000 + nanosec
+    return ROSTime(0.0, total_ns)
+end
+
+function to_msg_duration(d::ROSDuration)
+    py"""
+    def create_duration_msg(sec, nanosec):
+        from builtin_interfaces.msg import Duration
+        msg = Duration()
+        msg.sec = int(sec)
+        msg.nanosec = int(nanosec)
+        return msg
+    """
+    ns = d._py_duration.nanoseconds
+    sec = ns ÷ 1_000_000_000
+    nanosec = ns % 1_000_000_000
+    return py"create_duration_msg"(sec, nanosec)
+end
+
+function from_msg_duration(msg_duration)
+    sec = msg_duration.sec
+    nanosec = msg_duration.nanosec
+    total_ns = sec * 1_000_000_000 + nanosec
+    return ROSDuration(0.0, total_ns)
+end
+
+export ROSTime, ROSDuration, ROSClock
+export now, ros_time_now, to_sec, to_nsec
+export to_msg_time, from_msg_time, to_msg_duration, from_msg_duration
+export builtin_interfaces
+
+end

--- a/src/timer.jl
+++ b/src/timer.jl
@@ -5,9 +5,13 @@ using ..Core
 
 mutable struct ROSTimer
     pytimer::PyObject
-    
-    function ROSTimer(node::ROSNode, period::Float64, callback::Function; 
-                     callback_group=nothing)
+
+    function ROSTimer(
+        node::ROSNode,
+        period::Float64,
+        callback::Function;
+        callback_group = nothing,
+    )
         py"""
         def create_timer(node, period, callback, callback_group=None):
             timer = node.create_timer(period, callback, callback_group=callback_group)


### PR DESCRIPTION
## Overview
This PR adds comprehensive time management capabilities to ROS2.jl, providing ROS time types and operations for precise timestamp handling.

## Changes

### New Module: `src/time.jl`
- `ROSTime`: ROS time representation
- `ROSDuration`: Duration representation
- `ROSClock`: Clock interface
- `now()`: Get current ROS time
- `to_sec()`, `to_nsec()`: Time conversions
- `to_msg_time()`, `from_msg_time()`: Message time conversions
- `to_msg_duration()`, `from_msg_duration()`: Message duration conversions
- Arithmetic operations: `+`, `-`, `*` for time and duration
- Comparison operations: `==`, `<`, `<=` for time and duration

### New Example: `examples/example_time.jl`
Demonstrates time management with periodic publishing of timestamped PoseStamped messages at 10 Hz.

## API Example

```julia
using ROS2

init()
node = ROSNode("time_example")

# Get current time
current_time = now()
println("Current time: $(to_sec(current_time)) seconds")

# Create duration
duration = ROSDuration(1.0, 0)  # 1 second

# Time arithmetic
future_time = current_time + duration

# Convert to message
pose_msg = create_msg("geometry_msgs.msg.PoseStamped")
pose_msg.header.stamp = to_msg_time(current_time)
pose_msg.header.frame_id = "map"

shutdown()
```

## Features
- Full arithmetic support for time calculations
- Seamless conversion between ROS time and Julia types
- Integration with message timestamps
- Support for ROS clock types (system, steady, ROS)

## Testing
Tested with:
- ROS2 Humble on Ubuntu 22.04
- ROS2 Jazzy on Ubuntu 24.04
- Time arithmetic operations
- Message timestamp handling

## Backward Compatibility
Fully backward compatible. All existing code continues to work without modifications.